### PR TITLE
caches settings

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -52,6 +52,12 @@ jobs:
             ${{ runner.os }}-build-
             ${{ runner.os }}-
 
+      - name: cache check
+        run: |
+          echo "-->${{steps.cache-node-modules.outputs.cache-hit}}<--"
+          echo "-->${{steps.cache-npm.outputs.cache-hit}}<--"
+          echo "-->${{steps.cache-docker.outputs.cache-hit}}<--"
+
       - name: Build containers
         run: docker-compose build
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -39,24 +39,10 @@ jobs:
             ${{ runner.os }}-build-
             ${{ runner.os }}-
 
-      - name: Cache docker
-        uses: actions/cache@v2
-        id: cache-docker
-        env:
-          cache-name: cache-docker
-        with:
-          path: /var/lib/docker/
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Dockerfile') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-
       - name: cache check
         run: |
-          echo "-->${{steps.cache-node-modules.outputs.cache-hit}}<--"
-          echo "-->${{steps.cache-npm.outputs.cache-hit}}<--"
-          echo "-->${{steps.cache-docker.outputs.cache-hit}}<--"
+          echo "node-modules -->${{steps.cache-node-modules.outputs.cache-hit}}<--"
+          echo "npm -->${{steps.cache-npm.outputs.cache-hit}}<--"
 
       - name: Build containers
         run: docker-compose build

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -13,12 +13,40 @@ jobs:
 
       - name: Cache node modules
         uses: actions/cache@v2
+        id: cache-node-modules
         env:
           cache-name: cache-node-modules
         with:
           # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ./app/node_modules
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Cache npm
+        uses: actions/cache@v2
+        id: cache-npm
+        env:
+          cache-name: cache-npm
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
           path: ~/.npm
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Cache docker
+        uses: actions/cache@v2
+        id: cache-docker
+        env:
+          cache-name: cache-docker
+        with:
+          path: /var/lib/docker/
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Dockerfile') }}
           restore-keys: |
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,8 +13,23 @@ jobs:
 
       - name: Cache node modules
         uses: actions/cache@v2
+        id: cache-node-modules
         env:
           cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ./app/node_modules
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Cache npm
+        uses: actions/cache@v2
+        id: cache-npm
+        env:
+          cache-name: cache-npm
         with:
           # npm cache files are stored in `~/.npm` on Linux/macOS
           path: ~/.npm
@@ -23,6 +38,11 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
+
+      - name: cache check
+        run: |
+          echo "node-modules -->${{steps.cache-node-modules.outputs.cache-hit}}<--"
+          echo "npm -->${{steps.cache-npm.outputs.cache-hit}}<--"
 
       - name: Build containers
         run: docker-compose build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,23 @@ jobs:
 
       - name: Cache node modules
         uses: actions/cache@v2
+        id: cache-node-modules
         env:
           cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ./app/node_modules
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Cache npm
+        uses: actions/cache@v2
+        id: cache-npm
+        env:
+          cache-name: cache-npm
         with:
           # npm cache files are stored in `~/.npm` on Linux/macOS
           path: ~/.npm
@@ -23,6 +38,11 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
+
+      - name: cache check
+        run: |
+          echo "node-modules -->${{steps.cache-node-modules.outputs.cache-hit}}<--"
+          echo "npm -->${{steps.cache-npm.outputs.cache-hit}}<--"
 
       - name: Build containers
         run: docker-compose build


### PR DESCRIPTION
# Issue
- Resolve #9

# Implementations
- caches settings of docker
- caches settings of node modules

# Review points
- success of creating caches

# Attentions
- Docker caching is not supported by GitHub Actions (see actions/cache#31).

# Related to
- 
